### PR TITLE
Set maximum width for homepage cards

### DIFF
--- a/global.css
+++ b/global.css
@@ -42,6 +42,9 @@ input[type="search"] {
     overflow: hidden;
     text-decoration: none;
     color: inherit;
+    max-width: 350px;
+    width: 100%;
+    margin: 0 auto;
 }
 .card img {
     width: 100%;


### PR DESCRIPTION
## Summary
- limit `.card` width to 350px to keep grid items from growing too wide

## Testing
- `git status --short`