### PR TITLE
Add compute shader driven Game of Life demo

### DIFF
--- a/components/site-header.js
+++ b/components/site-header.js
@@ -1,0 +1,11 @@
+/* /components/site-header.js  –  simple site header */
+customElements.define('site-header', class extends HTMLElement {
+  connectedCallback() {
+    const brand = this.getAttribute('brand') ?? 'My Blog';
+    const sticky = this.hasAttribute('sticky');
+    this.innerHTML = `
+      <header class="site-header${sticky ? ' sticky' : ''}">
+        <a class="brand" href="/">${brand}</a>
+      </header>`;
+  }
+});

--- a/posts.json
+++ b/posts.json
@@ -1,5 +1,13 @@
 [
   {
+    "slug": "2025-05-23-game-of-life",
+    "title": "Conway's Game of Life",
+    "subtitle": "Cellular automation in 3D",
+    "cover": "https://picsum.photos/seed/gameoflife/400/300",
+    "date": "2025-05-23",
+    "tags": ["demo", "three.js"]
+  },
+  {
     "slug": "2025-05-22-hello",
     "title": "Hello World",
     "subtitle": "Kicking off the blog",

--- a/posts/2025-05-23-game-of-life/index.html
+++ b/posts/2025-05-23-game-of-life/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Loading…</title>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+        "three/examples/": "https://unpkg.com/three@0.160.0/examples/"
+      }
+    }
+  </script>
+  <link rel="stylesheet" href="/global.css" />
+  <script type="module" src="/post-init.js"></script>
+  <style>
+    #life-canvas { width: 500px; height: 500px; display:block; margin:1rem auto; }
+  </style>
+</head>
+
+<body>
+  <site-header brand="My Blog" sticky></site-header>
+  <post-hero></post-hero>
+
+  <main class="post-main">
+    <p>A simple demo of Conway's Game of Life rendered with three.js.</p>
+    <canvas id="life-canvas"></canvas>
+  </main>
+  <site-footer></site-footer>
+
+  <script type="module" src="/components/site-header.js"></script>
+  <script type="module" src="/components/post-hero.js"></script>
+  <script type="module" src="/components/site-footer.js"></script>
+
+  <script type="module">
+    import * as THREE from 'three';
+    import { GPUComputationRenderer } from 'three/examples/jsm/misc/GPUComputationRenderer.js';
+
+    const size = 128;
+    const canvas = document.getElementById('life-canvas');
+    const renderer = new THREE.WebGLRenderer({ canvas });
+    renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+
+    const gpu = new GPUComputationRenderer(size, size, renderer);
+    const initialState = gpu.createTexture();
+    const data = initialState.image.data;
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = Math.random() > 0.5 ? 1 : 0;
+      data[i + 1] = 0;
+      data[i + 2] = 0;
+      data[i + 3] = 1;
+    }
+
+    const fragmentShader = /* glsl */`
+      #version 300 es
+      precision highp float;
+
+      in vec2 vUv;
+      out vec4 fragColor;
+
+      // Automatically supplied by GPUComputationRenderer
+      uniform sampler2D textureState;
+
+      uniform vec2 resolution;
+
+      void main() {
+        float state = texture(textureState, vUv).r;
+
+        float alive = 0.0;
+        // Count the 8 neighbours
+        for (int j = -1; j <= 1; ++j) {
+          for (int i = -1; i <= 1; ++i) {
+            if (i == 0 && j == 0) continue;
+            vec2 offs = vec2(float(i), float(j)) / resolution;
+            alive += texture(textureState, vUv + offs).r;
+          }
+        }
+
+        float next = 0.0;
+        if (alive == 3.0 || (state > 0.5 && alive == 2.0)) {
+          next = 1.0;
+        }
+        fragColor = vec4(next, 0.0, 0.0, 1.0);
+      }
+    `;
+
+    const lifeVar = gpu.addVariable('textureState', fragmentShader, initialState);
+    gpu.setVariableDependencies(lifeVar, [lifeVar]);
+    lifeVar.material.uniforms.resolution = { value: new THREE.Vector2(size, size) };
+
+    const err = gpu.init();
+    if (err) console.error(err);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.z = 1;
+    const quad = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 2),
+      new THREE.MeshBasicMaterial({ map: gpu.getCurrentRenderTarget(lifeVar).texture })
+    );
+    scene.add(quad);
+
+    function animate() {
+      requestAnimationFrame(animate);
+      gpu.compute();
+      quad.material.map = gpu.getCurrentRenderTarget(lifeVar).texture;
+      renderer.render(scene, camera);
+    }
+    animate();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `<site-header>` component module
- load three.js via import map in the Game of Life post
- include component scripts so they load as modules
- compute Conway's Game of Life state with `GPUComputationRenderer`

## Testing
- `npm test` *(fails: Could not find package.json)*