### PR TITLE
Disable rotation in spiral orbit controls

### DIFF
--- a/posts/2025-05-23-spiral-points/spiral-points.js
+++ b/posts/2025-05-23-spiral-points/spiral-points.js
@@ -21,7 +21,8 @@ export async function initSpiralPoints () {
   camera.position.z = 3;
 
   const controls = new OrbitControls(camera, renderer.domElement);
-  controls.enableRotate       = true;
+  controls.enableRotate       = false;
+  controls.mouseButtons.LEFT  = THREE.MOUSE.PAN;
   controls.screenSpacePanning = true;
   controls.enableDamping      = true;
   controls.dampingFactor      = 0.05;


### PR DESCRIPTION
## Summary
- lock orbit controls to panning/zooming in spiral post

## Testing
- `git status --short`